### PR TITLE
Fixing Build and Bin Path Definition in makefile

### DIFF
--- a/bflibc/makefile
+++ b/bflibc/makefile
@@ -17,6 +17,8 @@ help:
 
 COMPILER = gcc
 CONFIG = release
+BUILD_PATH = build/$(CONFIG)
+BIN_PATH = bin/$(CONFIG)/$(LIB_NAME)
 BUILD_TYPE = archive
 SOURCE_EXT = c
 HEADER_EXT = h

--- a/bflibcpp/makefile
+++ b/bflibcpp/makefile
@@ -18,6 +18,8 @@ help:
 COMPILER = g++
 CPPSTD = -std=c++20
 CONFIG = release
+BUILD_PATH = build/$(CONFIG)
+BIN_PATH = bin/$(CONFIG)/$(LIB_NAME)
 BUILD_TYPE = archive
 SOURCE_EXT = cpp
 HEADER_EXT = hpp

--- a/bfnet/makefile
+++ b/bfnet/makefile
@@ -18,6 +18,8 @@ help:
 COMPILER = g++
 CPPSTD = -std=c++20
 CONFIG = release
+BUILD_PATH = build/$(CONFIG)
+BIN_PATH = bin/$(CONFIG)/$(LIB_NAME)
 BUILD_TYPE = archive
 SOURCE_EXT = cpp
 HEADER_EXT = hpp

--- a/bftest/makefile
+++ b/bftest/makefile
@@ -17,6 +17,8 @@ help:
 
 COMPILER = gcc
 CONFIG = release
+BUILD_PATH = build/$(CONFIG)
+BIN_PATH = bin/$(CONFIG)/$(LIB_NAME)
 BUILD_TYPE = archive
 SOURCE_EXT = c
 HEADER_EXT = h

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -10,6 +10,14 @@ ifeq ($(LIBS_MAKEFILES_PATH),)
 $(error ERROR: "please define `LIBS_MAKEFILES_PATH` in your makefile. this should be the absolute path to build.mk")
 endif
 
+ifeq ($(BUILD_PATH),)
+$(error ERROR: "please define `BUILD_PATH` in your makefile.")
+endif
+
+ifeq ($(BIN_PATH),)
+$(error ERROR: "please define `BIN_PATH` in your makefile.")
+endif
+
 include $(LIBS_MAKEFILES_PATH)/libpaths.mk 
 include $(LIBS_MAKEFILES_PATH)/platforms.mk 
 
@@ -19,8 +27,8 @@ rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(su
 UNAME_S := $(shell uname -s)
 
 CONFIG = release
-BUILD_PATH = build/$(CONFIG)
-BIN_PATH = bin/$(CONFIG)/$(LIB_NAME)
+#BUILD_PATH = build/$(CONFIG)
+#BIN_PATH = bin/$(CONFIG)/$(LIB_NAME)
 
 # BUILD_TYPE = archive || executable
 ifeq ($(BUILD_TYPE),)


### PR DESCRIPTION
* Requiring users to define `BUILD_PATH` and `BIN_PATH` in their makefiles